### PR TITLE
OSX Scripts (Mac OS)

### DIFF
--- a/osx/delete-inventory-export-csvs.sh
+++ b/osx/delete-inventory-export-csvs.sh
@@ -1,0 +1,12 @@
+rm -f 1-FFRK-Inventory-Relics.csv
+rm -f 2-FFRK-Soul_Breaks.csv
+rm -f 3-FFRK-Vault-Relics.csv
+rm -f 4-FFRK-Abilities.csv
+rm -f 5-FFRK-Magicite.csv
+rm -f 6-FFRK-Orbs.csv
+rm -f 7-FFRK-Legend_Materia.csv
+rm -f X-FFRK-Inventory-Record_Materia.csv
+rm -f X-FFRK-Characters.csv
+rm -f X-FFRK-Vault-Record_Materia.csv
+rm -f X-FFRK-Vault-Magicite.csv
+rm -f X-FFRK-Equipment-Collection.csv

--- a/osx/export-inventory.sh
+++ b/osx/export-inventory.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo "FFRK Inventory Exporter"
+echo "Use the following IP Address for your proxy: "
+./ip_address.sh
+
+./ip_address.sh | xargs -I{} mitmdump -q --listen-host {} --listen-port 8888 -s ../FFRK_Inventory_Exporter_v3.16.py

--- a/osx/ip_address.sh
+++ b/osx/ip_address.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+dumpIpForInterface()
+{
+  IT=$(ifconfig "$1") 
+  if [[ "$IT" != *"status: active"* ]]; then
+    return
+  fi
+  if [[ "$IT" != *" broadcast "* ]]; then
+    return
+  fi
+  echo "$IT" | grep "inet " | grep -v 127.0.0.1 | awk '{print $2}'
+}
+
+main()
+{
+  # snagged from here: https://superuser.com/a/627581/38941
+  DEFAULT_ROUTE=$(route -n get 0.0.0.0 2>/dev/null | awk '/interface: / {print $2}')
+  if [ -n "$DEFAULT_ROUTE" ]; then
+    dumpIpForInterface "$DEFAULT_ROUTE"
+  else
+    for i in $(ifconfig -s | awk '{print $1}' | awk '{if(NR>1)print}')
+    do 
+      if [[ $i != *"vboxnet"* ]]; then
+        dumpIpForInterface "$i"
+      fi
+    done
+  fi
+}
+
+main

--- a/osx/track-drops.sh
+++ b/osx/track-drops.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo "FFRK Drop Tracker"
+echo "Use the following IP Address for your proxy: "
+./ip_address.sh
+
+./ip_address.sh | xargs -I{} mitmdump -q --listen-host {} --listen-port 8888 -s ../FFRK_Drop_Tracker_v3.16.py


### PR DESCRIPTION
Did not update the Installation directions.  The only differences there are:

- Don't need to have the .NET Runtimes.
- User must pick a linux install path.  I used brew, but presumably the linux installer is similar to the Windows installer.
- User must run scripts from their 'osx' directory.  I'm not sure but user might need to modify permissions on the files to make them execute correctly.
- User does not need to find their IP Address through external means.  The script will provide it for them.  It can be modified to remind them to use port 8888 as well.